### PR TITLE
tarballs: implement limited support, only support binaries for now

### DIFF
--- a/upkg.sh
+++ b/upkg.sh
@@ -118,10 +118,10 @@ upkg_install() {
   while [[ -n $repospecs ]] && read -r -d $'\n' repospec; do
     if [[ $repospec =~ ^([^@/: ]+/[^@/: ]+)(@([^@ ]+))$ ]]; then
       repourl="https://github.com/${BASH_REMATCH[1]}.git"
-    elif [[ $repospec = https://github.com/* ]]; then
+    elif [[ $repospec =~ ^https://github.com/([^@/: ]+/[^@/: ]+)(@([^@ ]+))$ ]]; then
       repourl=${repospec%@*}
-    elif [[ $repospec =~ ([^@/: ]+/[^@/ ]+)(@([0-9a-f]{64}))$ ]]; then
-      upkg_install_tar "${repospec%@*}" "${BASH_REMATCH[3]}" "$pkgspath" "$binpath" "$tmppkgspath"
+    elif [[ $repospec =~ ([^@/: ]+/[^@/ ]+@([0-9a-f]{64})(#.*)?)$ ]]; then
+      upkg_install_tar "$repospec" "$pkgspath" "$binpath" "$tmppkgspath"
       continue
     else
       fatal "Unable to parse repospec '%s'. Expected a git cloneable URL followed by @version or tarball URL followed by @version (sha256sum)" "$repospec"


### PR DESCRIPTION
This maintains the overall public interface of `upkg` stable.

The entries added to the usage DOC, is only for descriptive reasons,
and to be able to explain the concept in more detail in the extended help text.

This adds support for downloading binaries shipped in tarballs, following a predefined tarball layout and a somewhat fixed URL scheme.

I'm certain that this doesn't follow or interact with the LOCK mechanisms correctly,
but I am a bit confused about the concepts, so I'll like a little bit of help with that part.


### TODO
  1. [ ] make `DRY_RUN` "work" / behave correctly with tarballs, whatever that behavior should be.
  2. [ ] interact with the locking mechanisms correctly.

### Things tested around this PR

1. empty install  
    ```
    $ ./upkg.sh install
    {  // upkg.json
        "commands": {
           "upkg": "upkg.sh"
        }
    }
    upkg: Installed all dependencies
    ```

    ```
    $ ./upkg.sh install
    {  // upkg.json
        "commands": {
           "upkg": "upkg.sh"
        },
        "dependencies": {
           "orbit-online/records.sh": "v0.9.5"
        }
    }
    upkg: Fetching orbit-online/records.sh@v0.9.5
    upkg: Installing orbit-online/records.sh@v0.9.5
    upkg: Installed all dependencies
    ```

    ```
    $ ./upkg.sh install
    {  // upkg.json
        "commands": {
           "upkg": "upkg.sh"
        },
        "dependencies": {
           "orbit-online/records.sh": "v0.9.5",
           "https://orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli-v0.1.0.tar.gz?X...": "69ac88324957d3efaa2616855c657be2de48e840b023282367b41c2f5f73ebcd"
        }
    }
    upkg: Fetching orbit-online/records.sh@v0.9.5
    upkg: Installing orbit-online/records.sh@v0.9.5
    upkg: Fetching orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli@v0.1.0
    upkg: Installing orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli@v0.1.0
    upkg: Installed all dependencies
    ```

2. local list
    ```
    $ ./upkg.sh list
    {  // upkg.json
        "commands": {
           "upkg": "upkg.sh"
        }
    }
    find: ‘/home/bkc/workspace/upkg/.upkg’: No such file or directory
    ```

    ```
    $ ./upkg.sh list
    {  // upkg.json
        "commands": {
           "upkg": "upkg.sh"
        },
        "dependencies": {
           "orbit-online/records.sh": "v0.9.5"
        }
    }
    orbit-online/records.sh@v0.9.5
    ```

    ```
    $ ./upkg.sh list
    {  // upkg.json
        "commands": {
           "upkg": "upkg.sh"
        },
        "dependencies": {
           "orbit-online/records.sh": "v0.9.5",
           "https://orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli-v0.1.0.tar.gz?X...": "69ac88324957d3efaa2616855c657be2de48e840b023282367b41c2f5f73ebcd"
        }
    orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli@v0.1.0
    orbit-online/records.sh@v0.9.5
    ```

3. global list  
    ```
    $ ./upkg.sh list -g
    orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli@v0.1.0
    orbit-online/bitwarden-tools@v1.4.12
    orbit-online/git-release@v0.3.1
    orbit-online/cli-tools@v1.0.4
    ...
    ```

4. install global  
    ```
    $ ./upkg.sh install -g "https://orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli-v0.1.0.tar.gz?X...@69ac88324957d3efaa2616855c657be2de48e840b023282367b41c2f5f73ebcd"
    upkg: Installed https://orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli-v0.1.0.tar.gz?X...@69ac88324957d3efaa2616855c657be2de48e840b023282367b41c2f5f73ebcd
    ```

    ```
    $ ./upkg.sh install -g orbit-online/records.sh@v0.9.5                              
    orbit-online/records.shonline/records.sh@v0.9.5upkg: Installed orbit- 
    online/records.sh@v0.9.5
    ```

5. removing package local  
   ```
   $ ./upkg.sh list
   {  // upkg.json
        "commands": {
           "upkg": "upkg.sh"
        },
        "dependencies": {
           "orbit-online/records.sh": "v0.9.5",
           "https://orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli-v0.1.0.tar.gz?X...": "69ac88324957d3efaa2616855c657be2de48e840b023282367b41c2f5f73ebcd"
        }
    }
    orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli@v0.1.0
    orbit-online/records.sh@v0.9.5
    $ ./upkg.sh install
    {  // upkg.json
        "commands": {
           "upkg": "upkg.sh"
        },
        "dependencies": {
           "orbit-online/records.sh": "v0.9.5"
        }
    }
    upkg: Uninstalling orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli
    upkg: Uninstalled orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli
    upkg: Installed all dependencies
    ```

7. uninstall global package  
   ```
   $ ./upkg.sh uninstall -g orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli
   upkg: Uninstalled orbit-binaries.s3.eu-west-1.amazonaws.com/orbit-cli
   ```

8. extended help message  
   ```
   $ ./upkg.sh -h
       upkg: μpkg - A minimalist package manager
    Usage:
      upkg install [-n] [-g [giturl]user/pkg@<version>]
      upkg install [-n] [-g tarballurl@<sha256sum>]
      upkg uninstall -g user/pkg
      upkg list [-g]
      upkg -h
    
    Options:
      -g  Act globally
      -n  Dry run, $?=1 if install/upgrade is required
      -h  Shows extended help message with examples and specifications
    
    Examples:
      Installing from git repo using github shorthand:
        upkg install -g orbit-online/records.sh@v0.9.5
    
      Installing from git repo with giturl:
        upkg install -g https://github.com/orbit-online/records.sh.git@v0.9.5
    
      Installing from tarballurl:
        upkg install -g https://organization.s3.amazonaws.com/optional/namespace/pkgname-v0.3.1.tar.gz@69ac88324957d3efaa2616855c657be2de48e840b023282367b41c2f5f73ebcd
    
    Specifications:
      tarballurl:
        <protocol>://[subdomain.]*domain.tld/[pathname/]*<pkgname>-v<pkgversion>.tar[.compression-extension][?GET-params...]@<sha256sum>
    
        For <protocol> http and https is supported, it comes down to what wget/curl supports
        Compression extensions supported comes down to what `tar xf` can auto detect, e.g. .gz, .bz2, .xz etc.
    
        <pkgversion> is only a symbolic notion used when listing packages, and must be prefixed with a `v`
    
        The filesystem location and effective pkgname is calculated from the tarballurl in the following manner.
          .upkg/lib/[subdomain.]domain.tld/[pathname.replace('/','.').]<pkgname>/bin/*
    
          Considering https://organization.s3.amazonaws.com/optional/namespace/pkgname-v0.3.1.tar.gz
          with tarball content of `bin/cli-tool` the filesystem layout will effectively be:
    
            .upkg/lib/organization.s3.amazonaws.com/optional.namespace.pkgname/bin/cli-tool
            .upkg/.bin/cli-tool -> ../lib/organization.s3.amazonaws.com/optional.namespace.pkgname/bin/cli-tool
    
          Considering https://raw.githubusercontent.com/pkgname-v0.3.1.tar.gz
          with tarball content of `bin/cli-tool` the filesystem layout will effectively be:
    
            .upkg/lib/raw.githubusercontent.com/pkgname/bin/cli-tool
            .upkg/.bin/cli-tool -> ../lib/raw.githubusercontent.com/pkgname/bin/cli-tool
   ```